### PR TITLE
Added source parameter

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,8 +2,10 @@ homepage: "https://rakutenadvertising.com/"
 documentation: "https://go.rakutenadvertising.com/hubfs/Rakuten-Affiliate-for-Server-Side-Google-Tag-Manager.pdf"
 versions:
   # Latest version
+  - sha: TBD
+    changeNotes: "Added source parameter to request" 
+  # Older versions
   - sha: 70950c3aed69380824f9a094f69532372f46a23d
     changeNotes: "Minor update: Removed test."
-  # Older versions
   - sha: c31162e73b83d6a65b46ecd6e429047569515cea
     changeNotes: "Initial release."

--- a/template.tpl
+++ b/template.tpl
@@ -824,6 +824,7 @@ requestUrl = requestUrl + "&" + enc(E).replace('RAN_', '') + "=" + enc(optionalD
         requestUrl += "&amtlist=" + itemvalue_list;
         requestUrl += "&img=1";
         requestUrl += "&spi=3.4.1";
+        requestUrl += "&source=sgtm";
 
         // namelist added at the end as it has lowest importance
         requestUrl += "&namelist=" + name_list;


### PR DESCRIPTION
I added a `source` parameter to the server request URL to help with conversion troubleshooting and better identifying the source. I assume the `SHA` value in `metadata.yaml` still needs to be updated once we have a commit.